### PR TITLE
stratum : algos/makefile : add gltalgos.c

### DIFF
--- a/stratum/algos/makefile
+++ b/stratum/algos/makefile
@@ -20,7 +20,7 @@ SOURCES=lyra2re.c lyra2v2.c Lyra2.c lyra2z.c Lyra2-z.c lyra2vc0ban.c Sponge.c al
 	a5a.c a5amath.c m7m.c magimath.cpp velvet.c \
 	argon2a.c blake2/blake2b.c ar2/argon2.c ar2/core.c ar2/encoding.c ar2/opt.c ar2/thread.c ar2/ar2-scrypt-jane.c \
 	hive.c pomelo.c hex.c argon2d-dyn.c \
-	phi.c phi2.c polytimos.c rainforest.c skunk.c sib.c veltor.c gost.c aergo.c lbk3.c pipehash.c \
+	phi.c phi2.c polytimos.c rainforest.c skunk.c sib.c veltor.c gost.c aergo.c lbk3.c pipehash.c gltalgos.c \
 	yespower.c yespower-opt.c sha256-P.c dedal.c
 
 OBJECTS=$(SOURCES:%.c=%.o) $(SOURCES:%.cpp=%.o)


### PR DESCRIPTION
Without this change, an error happens during stratum compilation:
stratum.o:(.data+0x2928): undefined reference to `astralhash_hash'
stratum.o:(.data+0x29a0): undefined reference to `jeonghash_hash'
stratum.o:(.data+0x2a18): undefined reference to `pawelhash_hash'
collect2: error: ld returned 1 exit status
Makefile:46: recipe for target 'stratum' failed
make: *** [stratum] Error 1

After this change, no error occurs during stratum compilation.